### PR TITLE
orpgHO/index.html 에 오타를 수정했습니다.

### DIFF
--- a/orpgHO/index.html
+++ b/orpgHO/index.html
@@ -66,7 +66,7 @@
             </article>
             <div class="cover ho_front">
                 <p>　</p>
-                <div class="ho_wrap" style="claer:both;">
+                <div class="ho_wrap" style="clear:both;">
                     <p class="ho_title">Handout</p>
                     <div class="inner_hwrap">
                         <div class="ho_name"> <span class="hname">이름</span><span class="sma"></span></div>
@@ -116,8 +116,7 @@
             <p>　</p>
         </article>
         <div class="howtouse">
-            사용 방법 : 복사 버튼 클릭 후, roll20의 핸드아웃에 내용 붙여넣기 ! <br>
-            ※ '캐릭터'에 넣을 시, 인장을 등록할 때 삐뚤어지니 '핸드아웃'으로 만들어야 함
+            사용 방법 : 복사 버튼 클릭 후, roll20의 핸드아웃에 내용 붙여넣기 !
         </div>
     </main>
     <script src="../script/common/common.js"></script>


### PR DESCRIPTION
안녕하세요, @DanBi-Lee 님. 좋은 도구 만들어주셔서 감사합니다. roll20 에서 플레이 할 때마다 잘 사용하고 있습니다. :)

우연히 orpgHO/index.html 에 오타를 발견해 수정하고 PR 드립니다.

핸드아웃을 '캐릭터' 로 넣었을 때 인장과 겹치는 현상은 이 오타 때문에  발생했던 것 같습니다. 오타 수정 후에는 인장 다음줄부터 표시되는 것을 확인하고, 사용법 설명 내용 중 '캐릭터' 로 넣지 말고 '핸드아웃' 으로 만들어야 한다는 문구도 제거하였습니다.

감사합니다.